### PR TITLE
Small fixes

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,14 +5,14 @@
                 {% if site.social.github.user and site.social.github.repo %}
                     <li>
                         <iframe class="github-btn"
-                                src="http://ghbtns.com/github-btn.html?user={{ site.social.github.user }}&amp;repo={{ site.social.github.repo }}&amp;type=watch&amp;count=true"
+                                src="https://ghbtns.com/github-btn.html?user={{ site.social.github.user }}&amp;repo={{ site.social.github.repo }}&amp;type=watch&amp;count=true"
                                 width="90"
                                 height="20"
                                 title="Star on GitHub"></iframe>
                     </li>
                     <li>
                         <iframe class="github-btn"
-                                src="http://ghbtns.com/github-btn.html?user={{ site.social.github.user }}&amp;repo={{ site.social.github.repo }}&amp;type=fork&amp;count=true"
+                                src="https://ghbtns.com/github-btn.html?user={{ site.social.github.user }}&amp;repo={{ site.social.github.repo }}&amp;type=fork&amp;count=true"
                                 width="90"
                                 height="20"
                                 title="Fork on GitHub"></iframe>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -65,7 +65,9 @@
         </p>
 
         <ul class="bs-docs-footer-links muted">
-            <li>Currently v{{ site.project.version }}</li>
+            {% if site.project.version %}
+                <li>Currently v{{ site.project.version }}</li>
+            {% endif %}
             {% for l in site.links.footer %}
                 <li>&middot;</li>
                 <li>

--- a/_includes/jumbotron.html
+++ b/_includes/jumbotron.html
@@ -6,7 +6,9 @@
             <p class="lead">
                 <a href="{{ site.project.download_url }}" class="btn btn-outline-inverse btn-lg">Download</a>
             </p>
-            <p class="version">Currently v{{ site.project.version }}</p>
+            {% if site.project.version %}
+                <p class="version">Currently v{{ site.project.version }}</p>
+            {% endif %}
         </div>
     </div>
 {% else %}


### PR DESCRIPTION
Just two fixes:

- Use HTTPS links to GitHub social iFrames (content security policy will block loading them when on an HTTPS site otherwise!)
- Only show current version in footer if the version has actually been defined in the `_config.yml`