### PR TITLE
Prevent images from overflow

### DIFF
--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -1,6 +1,10 @@
 ---
 ---
 
+img {
+  max-width: 100%;
+}
+
 .bs-docs-masthead {
   padding-top: 50px;
   padding-bottom: 40px;


### PR DESCRIPTION
Should fix #7 and prevent images to overflow and not fit inside their parent div.